### PR TITLE
fix(db-migration): [ST-12345] migration that leads to fail

### DIFF
--- a/migrations.sh
+++ b/migrations.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+fetch_secrets() {
+    SECRET_NAME=$1
+    OUTPUT_FILE=$2
+
+    echo "Fetching secrets for: $SECRET_NAME"
+
+
+    # Get the secret value
+    SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id $SECRET_NAME --query 'SecretString' --output text)
+
+    if [ $? -ne 0 ]; then
+        echo "Error fetching secret: $SECRET_NAME"
+        exit 1
+    fi
+
+    echo $SECRET_VALUE | jq -r 'to_entries | .[] | "\(.key)=\(.value)"' >> $OUTPUT_FILE
+
+    if [ $? -ne 0 ]; then
+        echo "Error writing to file: $OUTPUT_FILE"
+        exit 1
+    fi
+
+    echo "Secrets for $SECRET_NAME written to $OUTPUT_FILE"
+}


### PR DESCRIPTION
CSS is inside a JAR, Path.of(URI) only works for real file systems (file:).
For jar: URIs Java needs a ZIP filesystem mounted

but this adding of zip file system was performed usually when VirtualKeyboardModule was loaded, because in DefaultVirtualKeyboardManager initialization there is a crucial part that indirectly created the ZIP filesystem: resourceFileSystem = FileSystems.newFileSystem(uri, emptyMap());

But VirtualKeyboardModule was not being loaded because it had an exception with a new way of loading modules in DefaultInjectorFactory (problem with request inject and the new way of loading:
return Optional.of((Module)bootsrapInjector.getInstance(aClass));
)